### PR TITLE
Rename covergae badge job to build and separate build from PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,16 +1,38 @@
-name: Update Coverage on Readme
+name: Push Builds 🐍
 on:
   push:
     branches:
-      - test-branch
+      - main
 jobs:
-  update-coverage-on-readme:
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry
+          poetry install
+          poetry build
+      - name: pylint and pycodestyle
+        run: |
+          poetry run pylint firestone test
+          poetry run pycodestyle --config .pycodestyle firestone test
+      - name: Test with pytest
+        run: |
+          poetry run pytest --color=yes --cache-clear --cov=firestone test/ > pytest-coverage.txt
 
       - name: Pytest coverage comment
         if: ${{ github.ref == 'refs/heads/main' }}
@@ -20,13 +42,13 @@ jobs:
           hide-comment: true
           pytest-coverage-path: pytest-coverage.txt
 
-      - name: Update Readme with Coverage Html
+      - name: Update README with Coverage HTML
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           sed -i '/<!-- Pytest Coverage Comment:Begin -->/,/<!-- Pytest Coverage Comment:End -->/c\<!-- Pytest Coverage Comment:Begin -->\n\${{ steps.summary_report.outputs.content }}\n<!-- Pytest Coverage Comment:End -->' ./README.md
-      - name: Commit & Push changes to Readme
+      - name: Commit & Push changes to README
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions-js/push@master
         with:
-          message: Update coverage on Readme
+          message: Update coverage on README
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,11 +1,9 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Push and PR Builds 🐍
+name: PR Builds 🐍
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
- Add initial unit test
- fix README
- Create pylint.yml
- Disable outside workflows
- Re-enable workflow and remove pylint.yml
- Only add covergae comment coverage wf
- Add permissions of ro-all to pr workflow
- Add initial support for components and set proper response codes
- Add path and  default query param support
- Add coverage badge to README on push to main
- Rename covergae badge job to build and separate build from PR
